### PR TITLE
fix(vite-config): for firefox and docker

### DIFF
--- a/frontend/docker-compose.yml
+++ b/frontend/docker-compose.yml
@@ -18,3 +18,5 @@ services:
         - action: sync
           path: .
           target: /app
+    environment:
+      - DOCKER=true

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,9 +3,11 @@ import react from '@vitejs/plugin-react';
 import tsConfigPaths from 'vite-tsconfig-paths';
 import tailwindcss from '@tailwindcss/vite';
 
+const isDocker = process.env.DOCKER === 'true';
+
 export default defineConfig({
 	base: '/',
-	plugins: [tailwindcss(), react(), tsConfigPaths()],
+	plugins: [react(), tsConfigPaths(), tailwindcss()],
 	preview: {
 		port: 8080,
 		strictPort: true,
@@ -13,7 +15,7 @@ export default defineConfig({
 	server: {
 		port: 5173,
 		strictPort: true,
-		host: true,
-		origin: 'http://0.0.0.0:5173',
+		// this is crucial, because Docker can not bind to localhost
+		host: isDocker ? '0.0.0.0' : '127.0.0.1',
 	},
 });


### PR DESCRIPTION
- the issue was that firefox was not working, because Vite was using an IPV6 address and Firefox was strictly expecting ipv4

=> Vite dev server is listening only on IPv6 (::1)
localhost resolves to both:
127.0.0.1 (IPv4)
::1 (IPv6)
Chrome automatically falls back to IPv6
Firefox does not fall back if IPv4 fails