### PR TITLE
refactor(db/user): remove schema creation from app startup and introduce Postgrator migrations

### DIFF
--- a/services/user-service/migrations/001.do.create_users.sql
+++ b/services/user-service/migrations/001.do.create_users.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS users (
+            id SERIAL PRIMARY KEY,
+            username TEXT UNIQUE NOT NULL,
+            password TEXT NOT NULL,
+            email TEXT NOT NULL,
+            avatar TEXT NOT NULL DEFAULT 'default.png',
+            created_at TIMESTAMP DEFAULT NOW()
+);

--- a/services/user-service/package-lock.json
+++ b/services/user-service/package-lock.json
@@ -22,6 +22,7 @@
         "fastify-plugin": "^5.1.0",
         "nodemon": "^3.1.11",
         "pg": "^8.16.3",
+        "postgrator": "^8.0.0",
         "zod": "^4.2.1"
       }
     },
@@ -1688,6 +1689,18 @@
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
       "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==",
       "license": "MIT"
+    },
+    "node_modules/postgrator": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/postgrator/-/postgrator-8.0.0.tgz",
+      "integrity": "sha512-Kaw+/Ibk59pFyFzhdTpiXB3JVi4LFGl2JZ9RiWQk7qCtKUMFY8rat6ek0S3ON7SA4gj1yt6tn5s0Ukok2xnUFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/postgres-array": {
       "version": "2.0.0",

--- a/services/user-service/package.json
+++ b/services/user-service/package.json
@@ -28,6 +28,7 @@
     "fastify-plugin": "^5.1.0",
     "nodemon": "^3.1.11",
     "pg": "^8.16.3",
+    "postgrator": "^8.0.0",
     "zod": "^4.2.1"
   },
   "type": "module",

--- a/services/user-service/src/plugins/db.js
+++ b/services/user-service/src/plugins/db.js
@@ -1,31 +1,50 @@
 import fastifyPlugin from 'fastify-plugin'
 import fastifyPostgres from '@fastify/postgres'
+import Postgrator from 'postgrator'
+import path from 'path'
 
-async function dbConnector(fastify, options) {
-
+async function dbConnector(app, options) {
   // REGISTER THE DATABASE
-  fastify.register(fastifyPostgres, {
-    connectionString: process.env.DATABASE_URL
-  })
+    app.register(fastifyPostgres, {
+        connectionString: process.env.DATABASE_URL
+    })
+
+    app.addHook('onReady', async () => {
+        const postgrator = new Postgrator({
+            migrationPattern: path.join(process.cwd(), 'migrations/*'),
+            driver: 'pg',
+            database: 'user_db',
+            schemaTable: 'schema_migrations',
+            execQuery: (query) => app.pg.query(query)
+        })
+
+        try {
+            const applied = await postgrator.migrate()
+            app.log.info({ applied }, 'Database migrations completed')
+        } catch (err) {
+            app.log.error(err, 'Database migration failed')
+            throw err // fail fast in CI
+        }
+    })
 
   // CREATE TABLE
-  fastify.addHook('onReady', async () => {
-    try {
-      await fastify.pg.query(`
-        CREATE TABLE IF NOT EXISTS users (
-            id SERIAL PRIMARY KEY,
-            username TEXT UNIQUE NOT NULL,
-            password TEXT NOT NULL,
-            email TEXT NOT NULL,
-            avatar TEXT NOT NULL DEFAULT 'default.png',
-            created_at TIMESTAMP DEFAULT NOW()
-        );
-      `)
-      fastify.log.info('User Table created (or already existed).')
-    } catch (err) {
-      fastify.log.error(err, 'Error creating User table')
-    }
-  })
+//   fastify.addHook('onReady', async () => {
+//     try {
+//       await fastify.pg.query(`
+//         CREATE TABLE IF NOT EXISTS users (
+//             id SERIAL PRIMARY KEY,
+//             username TEXT UNIQUE NOT NULL,
+//             password TEXT NOT NULL,
+//             email TEXT NOT NULL,
+//             avatar TEXT NOT NULL DEFAULT 'default.png',
+//             created_at TIMESTAMP DEFAULT NOW()
+//         );
+//       `)
+//       fastify.log.info('User Table created (or already existed).')
+//     } catch (err) {
+//       fastify.log.error(err, 'Error creating User table')
+//     }
+//   })
 }
 
 export default fastifyPlugin(dbConnector)


### PR DESCRIPTION
This PR introduces database migrations for the user service. **It does not affect other services.**

## Changes
- Add initial migration for `users` table, now including `avatar` and `created_at`
- Remove table creation from Fastify setup

## What was happening before
- Before this change, the database schema was created direclty in db.js. It was executed every time the service started.
- This caused a few problems, ex:
  - if we wanted to modify the table, such as add or remove column or change a table, we had to manually edit sql inside db.js and existing databases *would not update* automatically.
  - Other than that, schema changes would be implicit and hard to track since there would be no history of how the database evolved.
 
## Now what
Instead of defining the schema in code, each database change is written in a .sql file, like:
```pg
001.init.sql
002.add_avatar_column.sql
```

Then: 
1. on startup, postgrator checks which files have already run and skip them.
2. it records executed migrations a new table `schema_migrations`

Once again, this was only implemented in user-service. @viridian-green I suggest that later, when you start dealing with your database, check out [Postgrator](https://fastify.dev/docs/latest/Guides/Database/).

I'll go ahead and merge this one since its a refactor that affects only user service.
