### PR TITLE
fix: restore DATABASE_URL env var required for service connection

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,7 @@ services:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB}
+      DATABASE_URL: postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@database:5432/game_db
 
     ports:
       - "3002:3002"
@@ -78,6 +79,7 @@ services:
     POSTGRES_USER: ${POSTGRES_USER}
     POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     POSTGRES_DB: ${POSTGRES_DB}
+    DATABASE_URL: postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@database:5432/user_db
 
    ports:
      - "3003:3003"


### PR DESCRIPTION
This PR adds the DATABASE_URL environment variable back into docker-compose.yml for the game and user services.

This configuration was removed in a previous commit, likely during the migration to the .env file. However, our application code relies on process.env.DATABASE_URL to register the database plugin. It does not automatically construct the connection string from the individual POSTGRES_USER / PASS variables.

Without this variable, the databases are not set.
<img width="758" height="121" alt="Screenshot 2025-12-28 at 12 02 54" src="https://github.com/user-attachments/assets/268d57f4-d82b-43d5-8941-790c6cd26713" />

Changes:
- Restored DATABASE_URL in docker-compose.yml for both game and user services.
- Configured it to use the secure ${VARIABLES} from the .env file, so no secrets are exposed in the code.

**PS:** I'll update the README with a small tutorial on how to connect to DBeaver and check if the database has been correctly set up.
**PS.2:** This error was actually caught by Copilot when I was using it to understand the game logic so I could add the AI opponent.