### PR TITLE
fix: prevent page scroll on arrow key press during gameplay

### DIFF
--- a/frontend/src/pages/Game.tsx
+++ b/frontend/src/pages/Game.tsx
@@ -51,12 +51,12 @@ const Game = () => {
 		};
 
 		const handleKeyDown = (event: KeyboardEvent) => {
-			if (ws.readyState !== WebSocket.OPEN) return;
-
+			// Prevent scrolling the page FIRST, before any other checks
 			if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', ' '].includes(event.key)) {
-				// Prevent scrolling the page
 				event.preventDefault();
 			}
+
+			if (ws.readyState !== WebSocket.OPEN) return;
 
 			switch (event.key) {
 				case 'w':


### PR DESCRIPTION
## Description
Fixes #135 

This PR resolves the UX issue where pressing the down arrow key during gameplay causes the page to scroll, disrupting the game experience.

## Problem
The `event.preventDefault()` was placed after the WebSocket connection check, meaning that during brief moments when the WebSocket wasn't in the OPEN state (initial connection, reconnection), arrow key presses could still trigger default browser scrolling behavior.

## Solution
Moved the `event.preventDefault()` call to execute **before** the WebSocket state check in the `handleKeyDown` function. This ensures arrow keys and spacebar always prevent page scrolling during gameplay, regardless of connection state.

## Changes Made
- **File**: `frontend/src/pages/Game.tsx`
- **Lines modified**: 54-57 (moved preventDefault block before WebSocket check)
- No functional changes to game logic or WebSocket communication

## Testing
- [x] Tested locally - arrow keys no longer scroll the page during gameplay
- [x] Arrow Up/Down controls still work correctly for right paddle
- [x] W/S keys still work correctly for left paddle (except in AI mode)
- [x] Spacebar pause functionality unchanged
- [x] WebSocket connectivity and game state updates unaffected

## Additional Notes
This is a minimal, surgical fix that only reorders existing code for better reliability. No new dependencies or logic added.