### PR TITLE
Feat/ai game start page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import {
 	PublicOnlyRoute,
 	GameEnd,
 	GameStart,
+	AIGameStart,
 	Chat,
 	TermsOfService,
 	PrivacyPolicy,
@@ -87,6 +88,14 @@ function App() {
 							element={
 								<ProtectedRoute>
 									<GameStart />
+								</ProtectedRoute>
+							}
+						/>
+						<Route
+							path='/AI-game-start'
+							element={
+								<ProtectedRoute>
+									<AIGameStart />
 								</ProtectedRoute>
 							}
 						/>

--- a/frontend/src/pages/AIGameStart.tsx
+++ b/frontend/src/pages/AIGameStart.tsx
@@ -1,0 +1,69 @@
+import { PinkButton } from '@/components';
+import { useNavigate } from 'react-router-dom';
+import { nanoid } from 'nanoid';
+
+const AIGameStart = () => {
+	const navigate = useNavigate();
+
+	const leftPlayer = 'AI';
+	const rightPlayer = 'You';
+
+	const handleAIStartGame = () => {
+		const gameId = nanoid();
+		navigate(`/game/${gameId}`, {
+			state: {
+				leftPlayer,
+				rightPlayer,
+				mode: 'AI',
+			},
+		});
+	};
+
+	return (
+		<div className='flex min-h-screen flex-col items-center justify-center gap-6'>
+			<section className='flex flex-col items-center justify-center gap-6'>
+				<p className='text-accent-pink font-retro text-6xl font-bold'>Game Start</p>
+
+				<div className='flex items-stretch justify-center gap-10'>
+					<div className='bg-surface border-border shadow-elevated flex min-w-54 flex-col items-center justify-start gap-2 rounded-lg px-6 py-4 shadow'>
+						<p className='text-2xl'>{leftPlayer}</p>
+						<div className='flex w-full items-center justify-between'>
+							<p className='text-text-secondary'>Paddle:</p>
+							<p className='text-xl'>Left</p>
+						</div>
+					</div>
+
+					<div className='bg-surface border-border shadow-elevated flex min-w-54 flex-col items-center justify-start gap-2 rounded-lg px-6 py-4 shadow'>
+						<p className='text-2xl'>{rightPlayer}</p>
+						<div className='flex w-full items-center justify-between'>
+							<p className='text-text-secondary'>Paddle:</p>
+							<p className='text-xl'>Right</p>
+						</div>
+						<div className='flex w-full items-center justify-between'>
+							<p className='text-text-secondary'>Controls:</p>
+							<div className='flex gap-1'>
+								<kbd className='bg-background rounded border px-2 py-1 text-sm shadow-sm'>
+									&uarr;
+								</kbd>
+								<kbd className='bg-background rounded border px-2 py-1 text-sm shadow-sm'>
+									&darr;
+								</kbd>
+							</div>
+						</div>
+					</div>
+				</div>
+				<p className='text-xl'>First to score 11 points wins!</p>
+				
+				<PinkButton
+					text='Start Game'
+					onClick={() => {
+						handleAIStartGame();
+					}}
+					className='text-accent-pink'
+				/>
+			</section>
+		</div>
+	);
+};
+
+export default AIGameStart;

--- a/frontend/src/pages/Game.tsx
+++ b/frontend/src/pages/Game.tsx
@@ -9,7 +9,7 @@ const Game = () => {
 	const { state } = useLocation();
 	const leftPlayer = state?.leftPlayer ?? 'Player 1';
 	const rightPlayer = state?.rightPlayer ?? 'Player 2';
-	const mode = state?.mode ?? 'classic'; // Default to classic if not provided
+	const mode = state?.mode ?? 'local'; // Default to local if not provided
 	const { gameId } = useParams<{ gameId: string }>();
 
 	const [gameState, setGameState] = useState<GameState | null>(null);

--- a/frontend/src/pages/GameStart.tsx
+++ b/frontend/src/pages/GameStart.tsx
@@ -114,7 +114,7 @@ const GameStart = () => {
 						</div>
 					</div>
 				</div>
-				<p className='text-xl'>First to 11 points wins!</p>
+				<p className='text-xl'>First to score 11 points wins!</p>
 				{error && <ErrorMessage message={error} />}
 				<PinkButton
 					text='Start Game'

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -17,14 +17,7 @@ const Home: FC = () => {
 	const [showRest, setShowRest] = useState(!isFirstSession);
 
 	const handleAIGameStart = () => {
-		const gameId = nanoid();
-		navigate(`/game/${gameId}`, {
-			state: {
-				leftPlayer: "Computer",
-				rightPlayer: "You", // or logged-in user's name - "You" seems easier
-				mode: 'AI'
-			}
-		}); // or `navigate('/AI');` to allow user to pick sides 
+		navigate('/AI-game-start');
 	};
 
 	const handleLocalGameStart = () => {

--- a/frontend/src/pages/index.ts
+++ b/frontend/src/pages/index.ts
@@ -12,6 +12,7 @@ export { default as PublicOnlyRoute } from './PublicOnlyRoute';
 export { default as Canvas } from './Canvas';
 export { default as GameEnd } from './GameEnd';
 export { default as GameStart } from './GameStart';
+export { default as AIGameStart } from './AIGameStart';
 export { default as Profile } from './profile/Profile';
 export { default as PrivacyPolicy } from './PrivacyPolicy';
 export { default as TermsOfService } from './TermsOfService';


### PR DESCRIPTION
This PR introduces a new page, `AIGameStart.tsx`, specifically designed for the AI Match initialization flow. It was originally scaffolded from `GameStart.tsx` but has been significantly refactored to support a fixed single-player experience.

## Changes
### 1. Removed Features
- Opponent Input: 
Removed the text input field for opponent alias. The opponent is now statically defined.
- Side Switching: 
Removed the invalid "Switch Sides" (⇄) button and the corresponding `handleSideChange` logic. The player is locked to the Right side.
- Validation Logic: 
Removed error handling for empty aliases or self-play checks, as inputs are now hardcoded.
- Opponent Controls: 
Hided the "W/S" key hints for the Left player, since the AI does not use a keyboard.
- Auth Dependency: 
Removed `useAuth` hook usage; the current user is simply referred to as "You" instead of their database username.

### 2. Added / Modified Features
- Default Configuration:
   - Left Player: Hardcoded to `"AI"`.
   - Right Player: Hardcoded to `"You"`.
- Game Initialization:
    - The `navigate` function now passes an additional flag `mode: 'AI'` in the location state to alert the Game component this is a vs-computer match.
- UI Improvements:
    - Updated the flex container to items-stretch and justify-start. This ensures both the "AI" and "You" cards are exactly the same height and text is perfectly aligned at the top, regardless of content differences (like missing controls).
### Files Created
`AIGameStart.tsx`
### Routes Updated
`App.tsx`: Added route /AI-game-start.
`index.ts`: Exported the new component.
### Additional Cahnges
- `GameStart.tsx`:  added **score** to "First to 11 points wins!". Now: "First to **score** 11 points wins!".
- `Game.tsx`: as requested in a previous PR, I changed the default game mode name from "classic" to "local".
- `Home.tsx`: updated to allow correct redirection to `AIGameStart.tsx`.
