### PR TITLE
feat: add avatar proxy route

### DIFF
--- a/api-gateway/src/routes/user.js
+++ b/api-gateway/src/routes/user.js
@@ -8,7 +8,6 @@ async function userRoutes(fastify) {
     rewritePrefix: "/auth",
     replyOptions: {
       rewriteRequestHeaders: (originalReq, headers) => {
-        // Forward cookies for authentication
         if (originalReq.headers.cookie) {
           headers.cookie = originalReq.headers.cookie;
         }
@@ -24,8 +23,6 @@ async function userRoutes(fastify) {
     rewritePrefix: "/users",
     replyOptions: {
       rewriteRequestHeaders: (originalReq, headers) => {
-        // Modify REQUEST headers sent to upstream service
-        // originalReq.user is set by the auth plugin after JWT verification
         if (originalReq.user?.id) {
           headers["x-user-id"] = String(originalReq.user.id);
         }
@@ -39,6 +36,21 @@ async function userRoutes(fastify) {
       },
     },
   });
+
+    fastify.register(httpProxy, {
+        upstream: "http://user:3003",
+        prefix: "/api/avatars",
+        rewritePrefix: "/avatars",
+        replyOptions: {
+            rewriteRequestHeaders: (originalReq, headers) => {
+                if (originalReq.headers.cookie) {
+                    headers.cookie = originalReq.headers.cookie;
+                }
+                return headers;
+            },
+        },
+    });
+
 }
 
 export default fp(userRoutes);


### PR DESCRIPTION
This PR introduces avatar features.

The backend now serves avatar at `/api/avatars/{filename}`. Frontend can fetch from there.

All users default to "default.png" in the database, which i provide already:
<img width="694" height="678" alt="Screenshot 2026-01-22 at 14 09 07" src="https://github.com/user-attachments/assets/e340b39c-e90d-42e4-9972-2516db5fc535" />
Avatar upload endpoint: `POST /api/users/me/avatar`
