### PR TITLE
Remove game pause functionality

### DIFF
--- a/frontend/src/pages/Canvas.tsx
+++ b/frontend/src/pages/Canvas.tsx
@@ -66,22 +66,6 @@ const Canvas = ({ gameState }: CanvasProps) => {
 				ctx.fill();
 			}
 
-			if (gameState.phase === 'paused') {
-				ctx.fillStyle = '#d4d4d4';
-				ctx.font = '32px Retro, sans-serif';
-				ctx.textAlign = 'center';
-				ctx.textBaseline = 'middle';
-				ctx.fillText('Paused', CANVAS_WIDTH / 2, CANVAS_HEIGHT / 2);
-			}
-
-			if (gameState.phase === 'paused') {
-				ctx.fillStyle = '#d4d4d4';
-				ctx.font = '32px Retro, sans-serif';
-				ctx.textAlign = 'center';
-				ctx.textBaseline = 'middle';
-				ctx.fillText('Paused', CANVAS_WIDTH / 2, CANVAS_HEIGHT / 2);
-			}
-
 			// Paddles
 			ctx.fillStyle = '#e60076';
 			ctx.fillRect(20, gameState.paddles.left.y, PADDLE_WIDTH, PADDLE_HEIGHT);

--- a/frontend/src/pages/Game.tsx
+++ b/frontend/src/pages/Game.tsx
@@ -1,4 +1,3 @@
-import { PinkButton } from '@/components';
 import Canvas from './Canvas';
 import { useEffect, useRef, useState } from 'react';
 import { useParams, useLocation, useNavigate } from 'react-router-dom';
@@ -99,14 +98,6 @@ const Game = () => {
 						}),
 					);
 					break;
-				case ' ':
-					// TODO: handle pause on the server (send back pause state)
-					ws.send(
-						JSON.stringify({
-							type: 'TOGGLE_PAUSE',
-						}),
-					);
-					break;
 				case 'Escape':
 					// TODO check with Adele if this is the desired behavior
 					ws.close();
@@ -158,10 +149,6 @@ const Game = () => {
 		};
 	}, [navigate, gameId, mode]);
 
-	const handlePauseToggle = () => {
-		wsRef.current?.send(JSON.stringify({ type: 'TOGGLE_PAUSE' }));
-	};
-
 	useEffect(() => {
 		if (gameState?.phase === 'ended') {
 			const winner =
@@ -189,11 +176,6 @@ const Game = () => {
 				<p>{rightPlayer}</p>
 			</div>
 			<Canvas gameState={gameState} />
-			<PinkButton
-				className='text-accent-pink'
-				text={gameState?.phase === 'paused' ? 'Resume' : 'Pause'}
-				onClick={handlePauseToggle}
-			/>
 		</div>
 	);
 };

--- a/frontend/src/shared.types.ts
+++ b/frontend/src/shared.types.ts
@@ -23,7 +23,7 @@ export type Friend = {
 };
 
 // Game phase types
-export type GamePhase = 'countdown' | 'playing' | 'paused' | 'ended';
+export type GamePhase = 'countdown' | 'playing' | 'ended';
 
 // Game state structure that will be received from server
 export interface GameState {
@@ -57,7 +57,7 @@ export interface GameState {
 // WebSocket message types (examples)
 // NOTE: it is a contract between client and server, but currently not used in the codebase
 export interface WSMessage<TWSMessage> {
-	type: 'GAME_STATE' | 'TOGGLE_PAUSE' | 'MOVE_PADDLE';
+	type: 'GAME_STATE' | 'MOVE_PADDLE';
 	payload?: TWSMessage; // TODO replace by actual type
 }
 

--- a/services/game-service/src/game/game-logic.js
+++ b/services/game-service/src/game/game-logic.js
@@ -68,14 +68,6 @@ export function movePaddle(state, playerIndex, direction) {
   if (direction === 'down') paddle.dy = speed;
 }
 
-export function togglePause(state) {
-  if (state.game.phase === 'playing') {
-    state.game.phase = 'paused';
-  } else if (state.game.phase === 'paused') {
-    state.game.phase = 'playing';
-  }
-}
-
 export function moveBall(state) {
   const { ball: ballCfg } = GAME_CONFIG;
   const ball = state.ball;

--- a/services/game-service/src/websocket/websocket.js
+++ b/services/game-service/src/websocket/websocket.js
@@ -83,9 +83,6 @@ case 'RESET_GAME':
     case 'STOP_PADDLE':
       stopPaddle(state, payload.playerIndex);
       break;
-    case 'TOGGLE_PAUSE':
-      togglePause(state);
-      break;
     default:
       console.warn('[GAME WS] Unknown message type:', type);
   }


### PR DESCRIPTION
Removed the pause feature from the game.

- **Frontend**: Removed the "Pause" button, the "Paused" overlay in the canvas, and the corresponding `'paused'` state from shared types.
- **Backend**: Removed the `TOGGLE_PAUSE` WebSocket event and the game logic handling the paused phase.
- **Cleanup**: Deleted unused imports and commented-out legacy code related to pausing.

Closes #174 