### PR TITLE
feat: add check if user is already online when trying to login

### DIFF
--- a/services/user-service/src/routes/auth/auth.routes.js
+++ b/services/user-service/src/routes/auth/auth.routes.js
@@ -7,7 +7,8 @@ import {
     signToken,
     parseLoginBody,
     ensureExistingEmail,
-    ensureValidPassword
+    ensureValidPassword,
+    ensureUserIsNotOnline
 } from "../../services/auth.service.js";
 /**
  * Authentication routes
@@ -44,7 +45,7 @@ export default async function authRoutes(app) {
         await ensureValidPassword(password, user);
 
         const token = await signToken(app, user);
-
+        await ensureUserIsNotOnline(app, user.id);
         return reply
             .setCookie("access_token", token, {
                 httpOnly: true,

--- a/services/user-service/src/services/auth.service.js
+++ b/services/user-service/src/services/auth.service.js
@@ -94,6 +94,26 @@ export async function ensureValidPassword(password, user) {
     }
 }
 
+export async function ensureUserIsNotOnline(app, userId) {
+    const response = await fetch(`http://presence:3005/state/${userId}`, {
+        method: "GET",
+        credentials: "include",
+    });
+
+    if (!response.ok) {
+        const err = new Error("Failed to check user state");
+        err.statusCode = 500;
+        throw err;
+    }
+
+    const userState = await response.json();
+
+    if (userState.state === "online") {
+        const err = new Error("User is already online");
+        err.statusCode = 409;
+        throw err;
+    }
+}
 /**
  * Authenticate middleware - reads user info from headers
  * The API Gateway handles JWT verification and passes user info via headers


### PR DESCRIPTION
This PR introduces a check if user is already online before proceeding with authentication. This way, now users can't be logged in in more than one session at the same time.

@pebencze, for now backend return 409, which triggers the following message. However I would like to have a new code (ex. 419) that would explicitly say "User is already online. Please log out from other devices", since we already use 409 for register. I tried including this case in utils.ts but always got the message "Failed to fetch", even though my curl commands where returning the message defined in backend. Can you check this out? I couldn't figure it out.

<img width="724" height="573" alt="Screenshot 2026-01-29 at 18 01 25" src="https://github.com/user-attachments/assets/2cbce64c-4bae-4425-b4b1-c9f6ec5dbc4b" />
