### PR TITLE
Fix/frontend/chat

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from 'react';
-import { Routes, Route, Link } from 'react-router-dom';
+import { Routes, Route, Link, useLocation } from 'react-router-dom';
+import { isPublicRoute } from './utils/routes';
 import {
 	Home,
 	NotFound,
@@ -25,6 +26,7 @@ import { useAuth } from './hooks/useAuth';
 
 function App() {
 	const { isLoggedIn, isLoading } = useAuth();
+	const location = useLocation();
 
 	if (isLoading) {
 		return <Loading />;
@@ -144,7 +146,7 @@ function App() {
 					</Routes>
 				</Suspense>
 			</main>
-			<ChatWidget />
+			{!isPublicRoute(location.pathname) && <ChatWidget />}
 			<footer className='border-border bg-surface text-text-muted flex h-16 items-center justify-center gap-2 border-t px-6 text-center text-sm'>
 				<Link to='/privacy-policy' className='hover:text-text-secondary'>
 					Privacy Policy

--- a/frontend/src/components/chat/ChatMessages.tsx
+++ b/frontend/src/components/chat/ChatMessages.tsx
@@ -18,19 +18,19 @@ export function ChatMessages({
 		<div className='chat-messages h-full snap-y snap-end overflow-y-auto'>
 			{messages.map((msg, i) => (
 				<div key={i} className='message overflow-hidden py-2 break-words'>
-					{msg.kind === 'chat' ? (
+					{msg.kind === 'system' ? (
+						<span className='text-[var(--color-text-muted)]'>{msg.text}</span>
+					) : (
 						<>
 							<strong
 								className={
-									msg.username === currentUsername ? 'color-brand' : 'color-blue'
+									msg.username === currentUsername ? 'color-brand bold' : 'color-blue bold'
 								}
 							>
 								{msg.username}:{' '}
 							</strong>{' '}
 							<span>{msg.text}</span>
 						</>
-					) : (
-						<span className='text-blue'>{msg.text}</span>
 					)}
 				</div>
 			))}

--- a/frontend/src/components/chat/ChatWidget.tsx
+++ b/frontend/src/components/chat/ChatWidget.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { FaComments } from 'react-icons/fa';
 import { useAuth } from '../../hooks/useAuth';
 import { useFetchOnlineUsers } from '../../hooks/useFetchOnlineUsers';
@@ -23,25 +23,54 @@ const ChatWidget = () => {
 	const [expanded, setExpanded] = useState(false);
 	const [activeTab, setActiveTab] = useState<'agora' | 'people' | number>('agora');
 	const [privateTabs, setPrivateTabs] = useState<{ id: number; name: string }[]>([]);
-	const [privateMessages, setPrivateMessages] = useState({});
+	const [privateMessages, setPrivateMessages] = useState(() => {
+		const saved = localStorage.getItem('privateMessages');
+		return saved ? JSON.parse(saved) : {};
+	});
+	const [generalMessages, setGeneralMessages] = useState(() => {
+		const saved = localStorage.getItem('generalMessages');
+		return saved ? JSON.parse(saved) : [];
+	});
 
 	// Use chat socket hook for all chat logic, with private message handler
 	const {
 		ws,
-		messages: generalMessages,
+		messages: socketGeneralMessages,
 		sendMessage,
-	} = useChatSocket(Boolean(user), undefined, (from, text, kind = 'chat') => {
-		// Open conversation if not already open
-		setPrivateTabs((prev) => {
-			if (prev.some((u) => String(u.id) === String(from.id))) return prev;
-			return [...prev, { id: Number(from.id), name: from.username }];
-		});
-		// Add message to private messages
-		setPrivateMessages((prev) => ({
-			...prev,
-			[from.id]: [...(prev[from.id] || []), { kind, username: from.username, text }],
-		}));
-	});
+	} = useChatSocket(
+		Boolean(user),
+		undefined,
+		(from, text, kind = 'chat') => {
+			// Open conversation if not already open
+			setPrivateTabs((prev) => {
+				if (prev.some((u) => String(u.id) === String(from.id))) return prev;
+				return [...prev, { id: Number(from.id), name: from.username }];
+			});
+			// Add message to private messages
+			setPrivateMessages((prev) => {
+				const updated = {
+					...prev,
+					[from.id]: [...(prev[from.id] || []), { kind, username: from.username, text }],
+				};
+				localStorage.setItem('privateMessages', JSON.stringify(updated));
+				return updated;
+			});
+		},
+		generalMessages // Pass messages from localStorage as initialMessages
+	);
+
+	// Sync general messages from socket to state and localStorage
+	useEffect(() => {
+		setGeneralMessages(socketGeneralMessages);
+	}, [socketGeneralMessages]);
+
+	useEffect(() => {
+		localStorage.setItem('generalMessages', JSON.stringify(generalMessages));
+	}, [generalMessages]);
+
+	useEffect(() => {
+		localStorage.setItem('privateMessages', JSON.stringify(privateMessages));
+	}, [privateMessages]);
 	const {
 		users: onlinePeople,
 		loading: loadingOnline,
@@ -51,14 +80,23 @@ const ChatWidget = () => {
 	const sendGeneralMessage = (text: string) => {
 		if (!text) return;
 		sendMessage({ type: 'general_msg', text });
+		setGeneralMessages((prev) => {
+			const updated = [...prev, { kind: 'chat', username: user?.username, text }];
+			localStorage.setItem('generalMessages', JSON.stringify(updated));
+			return updated;
+		});
 	};
 	const sendPrivateMessage = (toId: number, text: string) => {
 		if (!text) return;
 		sendMessage({ type: 'private_msg', text, to: String(toId) });
-		setPrivateMessages((prev) => ({
-			...prev,
-			[toId]: [...(prev[toId] || []), { kind: 'chat', username: user?.username, text }],
-		}));
+		setPrivateMessages((prev) => {
+			const updated = {
+				...prev,
+				[toId]: [...(prev[toId] || []), { kind: 'chat', username: user?.username, text }],
+			};
+			localStorage.setItem('privateMessages', JSON.stringify(updated));
+			return updated;
+		});
 	};
 
 	const openPrivateTab = (person: { id: number; name: string }) => {

--- a/frontend/src/hooks/useChatSocket.tsx
+++ b/frontend/src/hooks/useChatSocket.tsx
@@ -9,8 +9,9 @@ export function useChatSocket(
 		text: string,
 		kind: 'chat' | 'system',
 	) => void,
+	initialMessages: ChatRenderMessage[] = [],
 ) {
-	const [messages, setMessages] = useState<ChatRenderMessage[]>([]);
+	const [messages, setMessages] = useState<ChatRenderMessage[]>(initialMessages);
 	const [isConnected, setIsConnected] = useState(false);
 	const ws = useRef<WebSocket | null>(null);
 

--- a/frontend/src/utils/routes.ts
+++ b/frontend/src/utils/routes.ts
@@ -1,0 +1,5 @@
+export function isPublicRoute(path: string): boolean {
+  const publicRoutes = ['/', '/login', '/register', '/privacy-policy', '/terms-of-service'];
+  if (publicRoutes.includes(path)) return true;
+  return false;
+}


### PR DESCRIPTION
This pull request introduces several improvements to the chat functionality and user experience in the frontend. The main changes include persisting chat messages in localStorage for both general and private chats, refining how chat messages are rendered (including system messages), and conditionally displaying the chat widget only on non-public routes.

**Chat persistence and state management:**

* General and private chat messages are now persisted in `localStorage`, ensuring that messages are retained across page reloads and browser sessions. The chat widget initializes its state from `localStorage` and keeps it in sync as messages are sent or received. [[1]](diffhunk://#diff-f9a3282b98bba6763b3d461314a5b83dbab4262126729b6441afaa46aa5e2d96L26-R73) [[2]](diffhunk://#diff-f9a3282b98bba6763b3d461314a5b83dbab4262126729b6441afaa46aa5e2d96R83-R99)
* The `useChatSocket` hook now accepts initial messages as a parameter, allowing the chat widget to hydrate its state from persisted data.

**Chat UI/UX improvements:**

* The chat message renderer in `ChatMessages` now displays system messages in a muted style and applies bold styling to usernames, improving message clarity and visual hierarchy.
* The chat widget is now only shown on non-public routes, determined by the new `isPublicRoute` utility function, which prevents the chat UI from appearing on pages like login or registration. [[1]](diffhunk://#diff-e56cb91573ddb6a97ecd071925fe26504bb5a65f921dc64c63e534162950e1ebL2-R3) [[2]](diffhunk://#diff-e56cb91573ddb6a97ecd071925fe26504bb5a65f921dc64c63e534162950e1ebR29) [[3]](diffhunk://#diff-e56cb91573ddb6a97ecd071925fe26504bb5a65f921dc64c63e534162950e1ebL147-R149) [[4]](diffhunk://#diff-53fbb2b79dd56dd763dadeb00f9bbd7f1d64616949d8abb55f4f186c7152ae31R1-R5)