### PR TITLE
feat: add checks in backend for existing username and email

### DIFF
--- a/services/user-service/src/services/user.service.js
+++ b/services/user-service/src/services/user.service.js
@@ -1,5 +1,5 @@
 import { updateUserSchema } from "../schemas/auth.schema.js";
-import { hashPassword } from "./auth.service.js";
+import { ensureNotExistingUsername, ensureNotExistingEmail, hashPassword } from "./auth.service.js";
 
 export function parseUpdateUserBody(req) {
     const result = updateUserSchema.safeParse(req.body);
@@ -13,6 +13,13 @@ export function parseUpdateUserBody(req) {
 }
 
 export async function updateUser(app, userId, updateData) {
+    if (updateData.username) {
+        await ensureNotExistingUsername(app, updateData.username);
+    }
+
+    if (updateData.email) {
+        await ensureNotExistingEmail(app, updateData.email);
+    }
     if (updateData.password) {
         updateData.password = await hashPassword(updateData.password);
     }


### PR DESCRIPTION
Add checks for existing username and email in update route. 
Users weren't able to update to existing email and username due to UNIQUE constraint in the database. However, database, threw a 500 error. This introduces a softer 409 Conflict error.