### PR TITLE
Fix/409 for existing username

### DIFF
--- a/services/user-service/migrations/001.do.create_users.sql
+++ b/services/user-service/migrations/001.do.create_users.sql
@@ -2,7 +2,7 @@ CREATE TABLE IF NOT EXISTS users (
             id SERIAL PRIMARY KEY,
             username TEXT UNIQUE NOT NULL,
             password TEXT NOT NULL,
-            email TEXT NOT NULL,
+            email TEXT UNIQUE NOT NULL,
             avatar TEXT NOT NULL DEFAULT 'default.png',
             created_at TIMESTAMP DEFAULT NOW()
 );


### PR DESCRIPTION
Fix and closes #233 

- Enforces that emails are unique by adding "UNIQUE" to database table. Because of that **everyone** must clean the volumes! @ProjectDaiana @viridian-green @schardot @pebencze 
- Fixes bug created in previous PR, now users can update their profile normally.
- Program throws an **409** error when a profile update failes (e.g. when username or email already exists) and it doesn't rely anymore on postgres **500** error.