### PR TITLE
fix: redirect a new remote game to remote page

### DIFF
--- a/frontend/src/pages/GameEnd.tsx
+++ b/frontend/src/pages/GameEnd.tsx
@@ -24,6 +24,8 @@ const GameEnd = () => {
 					mode: 'AI',
 				},
 			});
+		} else if (state.mode === 'remote') {
+			navigate(`/remote`);
 		} else {
 			navigate(`/game/${gameId}`, { state: { leftPlayer, rightPlayer } });
 		}


### PR DESCRIPTION
Fixes issue where users, after playing a remote game, click on "New Game" got redirected to a local game page. The fix is similar to how a new AI game its handled by using the `mode` flag.
Now, when user clicks "New Game" and `mode` === 'remote', the page is redirected to '/remote'. 

closes #234 