### PR TITLE
Refactor/envs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,6 @@ POSTGRES_PASSWORD=mypassword
 POSTGRES_DB=bla
 
 # External Ports (host machine)
-NGINX_HTTP_PORT=8080
 NGINX_HTTPS_PORT=8443
 POSTGRES_PORT=5432  # For external DB tools like DBeaver
 

--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,6 @@ POSTGRES_PASSWORD=mypassword
 POSTGRES_DB=bla
 
 # External Ports (host machine)
-NGINX_HTTPS_PORT=8443
 POSTGRES_PORT=5432  # For external DB tools like DBeaver
 
 # Cookie

--- a/.env.example
+++ b/.env.example
@@ -5,10 +5,6 @@
 # Database
 POSTGRES_USER=myuser
 POSTGRES_PASSWORD=mypassword
-POSTGRES_DB=bla
-
-# External Ports (host machine)
-POSTGRES_PORT=5432  # For external DB tools like DBeaver
 
 # Cookie
 COOKIE_SECRET=test_cookie_secret

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ jobs:
       POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
       POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
       POSTGRES_DB: ${{ secrets.POSTGRES_DB }}
-      POSTGRES_PORT: ${{ secrets.POSTGRES_PORT }}
       JWT_SECRET: ${{ secrets.JWT_SECRET }}
       COOKIE_SECRET: ${{ secrets.COOKIE_SECRET }}
       REDIS_PORT: ${{ secrets.REDIS_PORT }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ jobs:
       POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
       POSTGRES_DB: ${{ secrets.POSTGRES_DB }}
       POSTGRES_PORT: ${{ secrets.POSTGRES_PORT }}
-      NGINX_HTTPS_PORT: ${{ secrets.NGINX_HTTPS_PORT }}
       JWT_SECRET: ${{ secrets.JWT_SECRET }}
       COOKIE_SECRET: ${{ secrets.COOKIE_SECRET }}
       REDIS_PORT: ${{ secrets.REDIS_PORT }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ jobs:
       POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
       POSTGRES_DB: ${{ secrets.POSTGRES_DB }}
       POSTGRES_PORT: ${{ secrets.POSTGRES_PORT }}
-      NGINX_HTTP_PORT: ${{ secrets.NGINX_HTTP_PORT }}
       NGINX_HTTPS_PORT: ${{ secrets.NGINX_HTTPS_PORT }}
       JWT_SECRET: ${{ secrets.JWT_SECRET }}
       COOKIE_SECRET: ${{ secrets.COOKIE_SECRET }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,12 @@
 *.bak
 
 # Keep the directory structure
-!nginx/ssl/.gitkeep# Node.js
+!nginx/ssl/.gitkeep
+
+# Secrets (generated locally, never commit)
+secrets/
+
+# Node.js
 node_modules/
 npm-debug.log*
 yarn-debug.log*

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@
 
 # Generate SSL certificates if they don't exist
 setup:
+	@bash ./scripts/generate-secrets.sh
 	./scripts/generate-ssl-certs.sh
 
 
@@ -15,7 +16,7 @@ up: setup env
 	docker compose up -d
 
 # Start services with dev overrides
-dev: setup
+dev: setup env
 	docker compose -f docker-compose.yml -f docker-compose.dev.yml build
 	docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d
 
@@ -72,7 +73,7 @@ reset:
 	docker builder prune -af || true
 	@echo "Removing SSL certs to force regeneration..."
 	rm -rf nginx/ssl/*.crt nginx/ssl/*.key || true
-	$(MAKE) setup
+#	$(MAKE) setup
 # 	docker compose build --no-cache --pull
 # 	docker compose up --build -d
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ setup:
 ## === Lifecycle: start/stop/restart ===
 
 # Start services (base stack)
-up: setup
+up: setup env
 	docker compose up -d
 
 # Start services with dev overrides

--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ Before running the project, ensure you have the following installed:
    REDIS_PORT=6379
 
    # Nginx Ports
-   NGINX_HTTP_PORT=8080
    NGINX_HTTPS_PORT=8443
    ```
 

--- a/README.md
+++ b/README.md
@@ -84,8 +84,6 @@ Before running the project, ensure you have the following installed:
    REDIS_HOST=redis
    REDIS_PORT=6379
 
-   # Nginx Ports
-   NGINX_HTTPS_PORT=8443
    ```
 
    **Note**: Replace all placeholder values with secure, randomly generated strings. Never commit `.env` files to version control.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ Before running the project, ensure you have the following installed:
    POSTGRES_USER=myuser
    POSTGRES_PASSWORD=your_secure_password
    POSTGRES_DB=transcendence_db
-   POSTGRES_PORT=5432
 
    # JWT and Security
    JWT_SECRET=your_jwt_secret_key_here

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -30,7 +30,7 @@ services:
     env_file:
       - .env
     ports:
-      - "${NGINX_HTTPS_PORT:-8443}:443"
+      - "8443:443"
     volumes:
       - ./nginx/nginx.dev.conf:/etc/nginx/nginx.conf:ro
       - ./nginx/ssl:/etc/nginx/ssl:ro

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -9,8 +9,6 @@ services:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB}
-    ports:
-      - "${POSTGRES_PORT:-5432}:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./init-scripts:/docker-entrypoint-initdb.d

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -30,7 +30,6 @@ services:
     env_file:
       - .env
     ports:
-      - "${NGINX_HTTP_PORT:-8080}:80"
       - "${NGINX_HTTPS_PORT:-8443}:443"
     volumes:
       - ./nginx/nginx.dev.conf:/etc/nginx/nginx.conf:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,6 @@ services:
     env_file:
       - .env
     ports:
-      - "${NGINX_HTTP_PORT:-8080}:80"
       - "${NGINX_HTTPS_PORT:-8443}:443"
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
     env_file:
       - .env
     ports:
-      - "${NGINX_HTTPS_PORT:-8443}:443"
+      - "8443:443"
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
       - ./nginx/ssl:/etc/nginx/ssl:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,6 @@ services:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB}
-    ports:
-      - "${POSTGRES_PORT:-5432}:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./init-scripts:/docker-entrypoint-initdb.d

--- a/scripts/generate-secrets.sh
+++ b/scripts/generate-secrets.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SECRETS_DIR="${ROOT_DIR}/secrets"
+POSTGRES_SECRET_FILE="${SECRETS_DIR}/postgres_password"
+JWT_SECRET_FILE="${SECRETS_DIR}/jwt_secret"
+
+mkdir -p "${SECRETS_DIR}"
+
+echo "==> Ensuring secrets exist in ${SECRETS_DIR}"
+
+# Generate Postgres password (file-based) if missing
+if [ ! -f "${POSTGRES_SECRET_FILE}" ]; then
+  echo "  - Creating postgres_password secret..."
+  # 32 random bytes, base64-encoded
+  head -c 32 /dev/urandom | base64 > "${POSTGRES_SECRET_FILE}"
+  chmod 600 "${POSTGRES_SECRET_FILE}" || true
+else
+  echo "  - postgres_password already exists, leaving as-is."
+fi
+
+# Generate JWT secret if missing
+if [ ! -f "${JWT_SECRET_FILE}" ]; then
+  echo "  - Creating jwt_secret..."
+  # 64 random bytes, base64-encoded
+  head -c 64 /dev/urandom | base64 > "${JWT_SECRET_FILE}"
+  chmod 600 "${JWT_SECRET_FILE}" || true
+else
+  echo "  - jwt_secret already exists, leaving as-is."
+fi
+
+echo "==> Secrets setup complete."
+

--- a/services/chat-service/.env.example
+++ b/services/chat-service/.env.example
@@ -1,9 +1,5 @@
 # Example .env file for chat-service
 
-# Database (if needed)
-POSTGRES_USER=myuser
-POSTGRES_PASSWORD=mypassword
-POSTGRES_DB=mydb
 
 # JWT secret for authentication
 JWT_SECRET=your-super-secret-jwt-key-change-in-production

--- a/services/game-service/.env.example
+++ b/services/game-service/.env.example
@@ -1,4 +1,3 @@
-DATABASE_URL=postgres://myuser:mypassword@database:5432/game_db
 
 # Environment
 NODE_ENV=development

--- a/services/presence-service/src/app.js
+++ b/services/presence-service/src/app.js
@@ -42,8 +42,6 @@ await app.register(websocket);
 // Register routes
 await app.register(presenceRoutes);
 await app.register(stateRoutes, { prefix: "/" });
-await app.ready();
-console.log(app.printRoutes());
 
 export default app;
 

--- a/services/user-service/src/app.js
+++ b/services/user-service/src/app.js
@@ -40,7 +40,4 @@ const app = Fastify({
 app.register(plugins);
 app.register(routes);
 
-await app.ready();
-console.log(app.printRoutes());
-
 export default app;

--- a/services/user-service/src/routes/index.js
+++ b/services/user-service/src/routes/index.js
@@ -8,6 +8,4 @@ export default async function routes(app) {
     app.register(authRoutes, { prefix: '/auth' });
 
     app.register(userRoutes, { prefix: '/users'});
-
-    //console.log(app.printRoutes());
 }


### PR DESCRIPTION
This PR introduces some part of changes for env. Since my last try to merge env changes broke prod, let's do it bit by bit.

Environment setup
1. Added env target to up command — make up automatically syncs .env files before starting. no need to manually run make env first
2. Added scripts/generate-secrets.sh — generates postgres_password and jwt_secret if missing
3. Added secrets/ to .gitignore — prevents committing sensitive files
4. Integrated into setup target — secrets are generated automatically
5. Removed NGINX_HTTPS_PORT variable
6. Removed POSTGRES_DB and POSTGRES_PORT variables
7. Removed references to unused nginx HTTP port
8. Removed unnecessary route printing logs/comments in API gateway
9. Removed redundant setup calls from reset target