### PR TITLE
fix: multiple joins and welcomes

### DIFF
--- a/frontend/src/components/DropdownMenuAvatar.tsx
+++ b/frontend/src/components/DropdownMenuAvatar.tsx
@@ -35,6 +35,7 @@ const ProfileCard = () => {
 		sessionStorage.removeItem(CHAT_WIDGET_STORAGE_KEYS.privateTabs);
 		sessionStorage.removeItem(CHAT_WIDGET_STORAGE_KEYS.privateMessages);
 		sessionStorage.removeItem(CHAT_WIDGET_STORAGE_KEYS.generalMessages);
+		sessionStorage.removeItem(CHAT_WIDGET_STORAGE_KEYS.welcomeShown);
 		await fetch('/api/auth/signout', {
 			method: 'POST',
 			credentials: 'include',

--- a/frontend/src/components/chat/ChatWidget.tsx
+++ b/frontend/src/components/chat/ChatWidget.tsx
@@ -19,7 +19,7 @@ import { CHAT_WIDGET_STORAGE_KEYS } from '@/const';
 const ChatWidget = () => {
 	const { user } = useAuth();
 	const currentUserId = user?.id ? String(user.id) : undefined;
-	const { isConnected: isPresenceConnected, ws: presenceWs } = usePresenceSocket(Boolean(user));
+	const { ws: presenceWs } = usePresenceSocket(Boolean(user));
 	const { friends, refetch } = useFriends(currentUserId);
 	const [expanded, setExpanded] = useState(false);
 	const [activeTab, setActiveTab] = useState<'conversation_all' | 'users_list' | number>(
@@ -77,13 +77,6 @@ const ChatWidget = () => {
 	useEffect(() => {
 		setGeneralMessages(socketGeneralMessages);
 	}, [socketGeneralMessages, setGeneralMessages]);
-	// Clear general messages when user logs out or goes offline
-	useEffect(() => {
-		if (!user || !isPresenceConnected) {
-			setGeneralMessages([]);
-			sessionStorage.removeItem(CHAT_WIDGET_STORAGE_KEYS.generalMessages);
-		}
-	}, [user, isPresenceConnected, setGeneralMessages]);
 
 	const {
 		users: rawOnlinePeople,

--- a/frontend/src/const.ts
+++ b/frontend/src/const.ts
@@ -4,4 +4,6 @@ export const CHAT_WIDGET_STORAGE_KEYS = {
 	privateTabs: 'privateTabs',
 	privateMessages: 'privateMessages',
 	generalMessages: 'generalMessages',
+	welcomeShown: 'chat_welcome_shown',
+	joinedShown: 'chat_joined_shown',
 };

--- a/frontend/src/hooks/useChatSocket.tsx
+++ b/frontend/src/hooks/useChatSocket.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useRef, useState } from 'react';
 import type { ChatServerMessage, ChatRenderMessage } from '../components/chat/types/chat';
+import { CHAT_WIDGET_STORAGE_KEYS } from '@/const';
 
 export function useChatSocket(
 	enabled: boolean,
-	// recipientUserId?: string,
 	onPrivateMessage?: (
 		from: { id: string; username: string },
 		text: string,
@@ -14,9 +14,15 @@ export function useChatSocket(
 	const [messages, setMessages] = useState<ChatRenderMessage[]>(initialMessages);
 	const [isConnected, setIsConnected] = useState(false);
 	const ws = useRef<WebSocket | null>(null);
+	const welcomeShown = sessionStorage.getItem(CHAT_WIDGET_STORAGE_KEYS.welcomeShown)?.length;
+	const joinedShown = sessionStorage.getItem(CHAT_WIDGET_STORAGE_KEYS.joinedShown)?.length;
+	const didConnectRef = useRef(false);
 
 	useEffect(() => {
 		if (!enabled) return;
+		if (didConnectRef.current) return;
+
+		didConnectRef.current = true;
 		const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
 		const wsUrl = `${protocol}//${window.location.host}/api/chat/websocket`;
 		ws.current = new WebSocket(wsUrl);
@@ -51,9 +57,13 @@ export function useChatSocket(
 					]);
 					return;
 				case 'welcome':
+					if (welcomeShown) return;
+					sessionStorage.setItem(CHAT_WIDGET_STORAGE_KEYS.welcomeShown, 'true');
 					setMessages((prev) => [...prev, { kind: 'system', text: data.message }]);
 					return;
 				case 'user_joined':
+					if (joinedShown) return;
+					sessionStorage.setItem(CHAT_WIDGET_STORAGE_KEYS.joinedShown, 'true');
 					setMessages((prev) => [
 						...prev,
 						{ kind: 'system', text: `${data.user.username} joined` },


### PR DESCRIPTION
THIS PR BUILDS ON TOP OF FIX/LOCALSTORAGE. Please test and merge this first or change the base branch to develop.

I separated te PRs because this logic works but can be tested more.

## Features
- deduplicate 'welcome, user!' and 'user joined' messages => they only appear once by using refs and safeguarding the websocket