### PR TITLE
fix: username schemas to accept only letters, numbers and underscores

### DIFF
--- a/frontend/src/components/DropdownMenuAvatar.tsx
+++ b/frontend/src/components/DropdownMenuAvatar.tsx
@@ -30,19 +30,25 @@ const ProfileCard = () => {
 	const navigate = useNavigate();
 
 	const handleSignout = async () => {
-		navigate('/', { replace: true });
-		localStorage.clear();
-		sessionStorage.removeItem(CHAT_WIDGET_STORAGE_KEYS.privateTabs);
-		sessionStorage.removeItem(CHAT_WIDGET_STORAGE_KEYS.privateMessages);
-		sessionStorage.removeItem(CHAT_WIDGET_STORAGE_KEYS.generalMessages);
-		sessionStorage.removeItem(CHAT_WIDGET_STORAGE_KEYS.welcomeShown);
-		await fetch('/api/auth/signout', {
-			method: 'POST',
-			credentials: 'include',
-		});
-		setUser(null);
-		sessionStorage.removeItem(loginSessionStorageKey);
-		setIsLoggedIn(false);
+		try {
+			await fetch('/api/auth/signout', {
+				method: 'POST',
+				credentials: 'include',
+			});
+		} catch (err) {
+			console.error('Signout failed', err);
+		} finally {
+			localStorage.clear();
+			sessionStorage.removeItem(CHAT_WIDGET_STORAGE_KEYS.privateTabs);
+			sessionStorage.removeItem(CHAT_WIDGET_STORAGE_KEYS.privateMessages);
+			sessionStorage.removeItem(CHAT_WIDGET_STORAGE_KEYS.generalMessages);
+			sessionStorage.removeItem(CHAT_WIDGET_STORAGE_KEYS.welcomeShown);
+			sessionStorage.removeItem(loginSessionStorageKey);
+
+			setUser(null);
+			setIsLoggedIn(false);
+			navigate('/', { replace: true });
+		}
 	};
 
 	return (

--- a/frontend/src/pages/auth/Registration.tsx
+++ b/frontend/src/pages/auth/Registration.tsx
@@ -11,7 +11,11 @@ const registrationSchema = z
 		username: z
 			.string()
 			.min(1, 'Username is required')
-			.max(15, 'Username must be at most 15 characters'),
+			.max(15, 'Username must be at most 15 characters')
+			.regex(
+				/^[a-zA-Z0-9_]+$/,
+				'Username can only contain letters, numbers, and underscores',
+			),
 		password: z
 			.string()
 			.min(8, 'Password must be at least 8 characters')

--- a/frontend/src/pages/profile/ProfileSettingsCard.tsx
+++ b/frontend/src/pages/profile/ProfileSettingsCard.tsx
@@ -9,7 +9,8 @@ const profileUpdateSchema = z.object({
 	username: z
 		.string()
 		.min(1, 'Username is required')
-		.max(15, 'Username must be at most 15 characters'),
+		.max(15, 'Username must be at most 15 characters')
+		.regex(/^[a-zA-Z0-9_]+$/, 'Username can only contain letters, numbers, and underscores'),
 	bio: z.string().max(150, 'Bio must be at most 150 characters'),
 	avatar: z.string(),
 });

--- a/services/user-service/src/schemas/auth.schema.js
+++ b/services/user-service/src/schemas/auth.schema.js
@@ -8,7 +8,11 @@ export const registerSchema = z.object ({
 
     username: z
         .string().nonempty("Username required")
-        .max(15, "Username must be at most 15 characters"),
+        .max(15, "Username must be at most 15 characters")
+		.regex(
+			/^[a-zA-Z0-9_]+$/,
+			'Username can only contain letters, numbers, and underscores',
+		),
 
     password: z
         .string().nonempty("Password required")


### PR DESCRIPTION
fix: username schemas to accept only letters, numbers and underscores
- registration
- profile update